### PR TITLE
Avoid invoking `highlight clear` when the default colorscheme

### DIFF
--- a/lua/neosolarized.lua
+++ b/lua/neosolarized.lua
@@ -27,8 +27,12 @@ function M.setup(opts)
 
     cmd([[
         packadd! colorbuddy.nvim
-        highlight clear
     ]])
+
+    -- only needed to clear when not the default colorscheme
+    if vim.g.colors_name then
+      vim.cmd("hi clear")
+    end
 
     if fn.exists('syntax_on') then cmd('syntax reset') end
 


### PR DESCRIPTION
ref: https://github.com/folke/tokyonight.nvim/blob/main/lua/tokyonight/util.lua#L227

fix #4