### PR TITLE
Add colors for XML-like tags

### DIFF
--- a/lua/neosolarized.lua
+++ b/lua/neosolarized.lua
@@ -302,6 +302,11 @@ function M.setup(opts)
     Group.link('HopNextKey1', groups.IncSearch)
     Group.link('HopNextKey2', groups.IncSearch)
 
+    -- XML-like tags
+    Group.new("@tag", colors.green)
+    Group.new("@tag.attribute", colors.blue)
+    Group.new("@tag.delimiter", colors.red)
+
     function M.translate(group)
         if fn.has("nvim-0.6.0") == 0 then return group end
 


### PR DESCRIPTION
Recently, XML-like tags are not highlighted due to the changes in Treesitter.

## Before

<img width="660" alt="CleanShot 2022-11-06 at 09 39 20@2x" src="https://user-images.githubusercontent.com/1332805/200148746-d2027991-d845-42d4-b359-2fc88b3b79b7.png">

## After

This PR adds colors for them:

<img width="784" alt="CleanShot 2022-11-06 at 09 39 05@2x" src="https://user-images.githubusercontent.com/1332805/200148747-71823aba-f6a2-44ee-aa56-732fa69748b5.png">

fix https://github.com/craftzdog/dotfiles-public/issues/81