### PR TITLE
Optionally set the background with background_set

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Based on [NeoSolarized](https://github.com/overcache/NeoSolarized).
 
 I've used a bunch of solarized themes. The best I have found is NeoSolarized. Despite it
 being fantastic, like most themes, I wanted to tweak it here and there and really wanted a
-lua solution for this in the style of the latest and greatest neovim plugins that allow
-customizations via a setup function.
+lua solution for this in the style of the latest and greatest neovim plugins.
+
 
 ## Limitations
 
@@ -29,9 +29,14 @@ After installed colorbuddy and neosolarized.nvim with your favorite package mana
 lua << EOF
   require('neosolarized').setup({
     comment_italics = true,
+    background_set = false,
   })
 EOF
 ```
+
+This theme assumes you have a solarized background set for your terminal, but if you want the
+background set to the background in the photo, change `background_set' option in the your
+setup function to true.
 
 Example above is with the default settings.
 
@@ -52,7 +57,7 @@ again.
 
 ## Features
 
-- Easy customization without messing with nvim highlights
+- Easy customization with colorbuddy without messing with nvim highlights
 - LSP diagnostic colors (no need for lsp-colors, for example)
 
 ### Plugins supported

--- a/lua/neosolarized.lua
+++ b/lua/neosolarized.lua
@@ -3,6 +3,8 @@ local fn = vim.fn
 
 local defaults = {
     comment_italics = true,
+    background_set = false,
+    background_color = require('colorbuddy.init').Color.none,
 }
 
 local M = {
@@ -67,9 +69,15 @@ function M.setup(opts)
     Group.new('Information', colors.blue)
     Group.new('Hint', colors.cyan)
 
+    if opts["background_set"] and opts["background_color"] == Color.none then
+        opts["background_color"] = colors.base03
+    end
+
+    local bg_color = opts["background_color"]
+
     -- normal non-current text
-    Group.new('Normal', colors.base0, colors.NONE, styles.NONE)
-    Group.new('NormalNC', colors.base0:dark(), colors.NONE, styles.NONE)
+    Group.new('Normal', colors.base0, bg_color, styles.NONE)
+    Group.new('NormalNC', colors.base0:dark(), bg_color, styles.NONE)
 
     Group.new('Comment', colors.base01, colors.none, opts.comment_italics and styles.italic or styles.NONE)
     Group.new('Constant', colors.cyan, colors.none, styles.NONE)
@@ -134,7 +142,7 @@ function M.setup(opts)
     Group.new('TabLineFill', colors.base0, colors.base02)
     Group.new('TabLineSel', colors.yellow, colors.bg)
 
-    Group.new('LineNr', colors.base01, colors.none, styles.NONE)
+    Group.new('LineNr', colors.base01, bg_color, styles.NONE)
     Group.new('CursorLine', colors.none, colors.base02, styles.NONE, colors.base1)
     Group.new('CursorLineNr', colors.none, colors.none, styles.NONE, colors.base1)
     Group.new('ColorColumn', colors.none, colors.base02, styles.NONE)


### PR DESCRIPTION
Use background_color to set the color. Defaults to base03 if background_set is true, otherwise is not set, meaning that the background will inherit the color of the terminal.

Resolves #10 